### PR TITLE
Feature/hackclub auth

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,12 +1,12 @@
-import type { PageServerLoad } from './$types';
-import { redirect } from '@sveltejs/kit';
+// import type { PageServerLoad } from './$types';
+// import { redirect } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ locals }) => {
-	const session = await locals.auth();
+// export const load: PageServerLoad = async ({ locals }) => {
+// 	const session = await locals.auth();
 
-	if (session) {
-		throw redirect(302, '/home');
-	}
+// 	if (session) {
+// 		throw redirect(302, '/home');
+// 	}
 
-	return {};
-};
+// 	return {};
+// };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,12 +1,8 @@
-// import type { PageServerLoad } from './$types';
-// import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
 
-// export const load: PageServerLoad = async ({ locals }) => {
-// 	const session = await locals.auth();
-
-// 	if (session) {
-// 		throw redirect(302, '/home');
-// 	}
-
-// 	return {};
-// };
+export const load: PageServerLoad = async ({ locals }) => {
+  const session = await locals.auth();
+  return {
+    session
+  };
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { signIn, signOut } from '@auth/sveltekit/client';
 	import pxlTitle from '$lib/assets/pxl-title.png';
 	import '$lib/assets/styles/home.css';
+	import { redirect } from '@sveltejs/kit';
 </script>
 
 <svelte:head>
@@ -11,5 +12,6 @@
 <div class="home-wrapper">
 	<img src={pxlTitle} alt="PXL logo" class="pxl-logo" />
 	<!-- <button on:click={() => signIn("github")}>Sign in with GitHub</button> -->
-	<button on:click={() => signIn('slack')}>Sign in with Slack</button>
+	<button on:click={() => signIn('hackclub', { callbackUrl: '/home' })}
+		>Sign in with Hackclub</button>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,6 @@
 	import { signIn, signOut } from '@auth/sveltekit/client';
 	import pxlTitle from '$lib/assets/pxl-title.png';
 	import '$lib/assets/styles/home.css';
-	import { redirect } from '@sveltejs/kit';
 </script>
 
 <svelte:head>

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -28,5 +28,5 @@
 	<button on:click={handleSignOut}>Sign out</button>
 {:else}
 	<!-- <button on:click={() => signIn("github")}>Sign in with GitHub</button> -->
-	<button on:click={() => signIn('slack')}>Sign in with Slack</button>
+	<button on:click={() => signIn('hackclub')}>Sign in with Hackclub</button>
 {/if}

--- a/src/routes/home/+page.server.ts
+++ b/src/routes/home/+page.server.ts
@@ -3,20 +3,18 @@ import { getUserFromEmail } from '$lib/server/db';
 import { redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const session = await locals.auth();
+  const session = await locals.auth();
 
-	// const allowed_emails = ["ben.elliott.2021@gmail.com","web@niiccoo2.xyz"];
-	const email = session?.user?.email ?? null;
+  const email = session?.user?.email;
+  if (!email) {
+    throw redirect(302, '/');
+  }
 
-	if (!email) {
-		redirect(302, '/');
-	}
+  const user = getUserFromEmail.get({ email });
 
-	const user = getUserFromEmail.get({ email });
+  const admin_viewer = user?.is_admin ?? false;
 
-	const admin_viewer = user?.is_admin ?? false;
-
-	return {
-		admin_viewer
-	};
+  return {
+    admin_viewer
+  };
 };

--- a/src/routes/shop/+page.server.ts
+++ b/src/routes/shop/+page.server.ts
@@ -5,7 +5,6 @@ import { redirect } from '@sveltejs/kit';
 export const load: PageServerLoad = async ({ locals }) => {
 	const session = await locals.auth();
 
-	// const allowed_emails = ["ben.elliott.2021@gmail.com","web@niiccoo2.xyz"];
 	const email = session?.user?.email ?? null;
 
 	if (!email) {

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,0 +1,7 @@
+import "@auth/core/types";
+
+declare module "@auth/core/types" {
+  interface Session {
+    accessToken?: string;
+  }
+}


### PR DESCRIPTION
This pull request updates the authentication flow to use Hack Club as the OAuth provider instead of Slack, and refactors related logic to support this change. The most important changes include implementing a custom Hack Club OAuth provider, updating sign-in buttons and session handling, and cleaning up authentication and redirect logic across several routes.

**Authentication provider migration:**

* Added a custom Hack Club OAuth provider implementation in `src/hooks.server.ts`, replacing the previous Slack provider. The provider maps Hack Club profile data to the Auth.js user format and updates JWT and session callbacks to populate user information from Hack Club.
* Updated sign-in buttons in `src/routes/+page.svelte` and `src/routes/account/+page.svelte` to use Hack Club instead of Slack for authentication. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL14-R15) [[2]](diffhunk://#diff-914f3bf0037756030c38348c9f5a2be2cd7315be02b5306591e592a368d7247dL31-R31)

**Session and redirect logic improvements:**

* Refactored session handling in `src/hooks.server.ts` to ensure `session.user` is always populated with Hack Club profile data.
* Simplified the logic in `src/routes/+page.server.ts` to return the session object directly, removing the previous redirect to `/home` for authenticated users.
* Improved authentication checks and redirects in `src/routes/home/+page.server.ts` to throw a redirect if no email is present in the session, using cleaner error handling.

**Other minor cleanup:**

* Removed unused allowed email logic in `src/routes/shop/+page.server.ts` for clarity.