### PR TITLE
Fix/canvas pan placing

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -176,6 +176,9 @@
 		x = Math.round(x / safePixelSize);
 		y = Math.round(y / safePixelSize);
 
+		x = x + offsetX;
+		y = y + offsetY;
+
 		console.log(`Found x and y: (${x}, ${y})`);
 
 		if (editable == false) {

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -176,8 +176,8 @@
 		x = Math.round(x / safePixelSize);
 		y = Math.round(y / safePixelSize);
 
-		x = x + offsetX;
-		y = y + offsetY;
+		x = x - offsetX;
+		y = y - offsetY;
 
 		console.log(`Found x and y: (${x}, ${y})`);
 

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -274,6 +274,7 @@
 			on:mousedown={onMouseDown}
 			on:mousemove={onMouseMove}
 			on:mouseup={onMouseUp}
+			on:contextmenu|preventDefault
 			style="image-rendering: pixelated;
           width: {width * safePixelSize}px;
           height: {height * safePixelSize}px;"

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -176,8 +176,8 @@
 		x = Math.round(x / safePixelSize);
 		y = Math.round(y / safePixelSize);
 
-		x = x - offsetX;
-		y = y - offsetY;
+		x = x - offsetX / safePixelSize;
+		y = y - offsetY / safePixelSize;
 
 		console.log(`Found x and y: (${x}, ${y})`);
 


### PR DESCRIPTION
Fixed the bug that placed pixels in wrong spot after you panned. Also disabled the right click context menu on the canvas.